### PR TITLE
Add table showing strength of passphrases according to length

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,12 @@ borrower harvest stature entity blimp
 $ git clone https://github.com/micahflee/passphraseme.git
 $ cp passphraseme/passphraseme /usr/local/bin
 ```
+
+## Strength of passphrases
+
+This table shows the strength (bits of entropy) of `passphraseme`-generated passphrases of different lengths (1-10 words).
+
+|                                | Bits of entropy/word | 1    | 2    | 3    | 4    | 5    | 6    | 7    | 8     | 9     | 10  |
+|--------------------------------|----------------------|------|------|------|------|------|------|------|-------|-------|-----|
+| EFF large wordlist (*default*) | 12.9                 | 12.9 | 25.8 | 38.7 | 51.6 | 64.5 | 77.4 | 90.3 | 103.2 | 116.1 | 129 |
+| EFF short wordlists            | 10.3                 | 10.3 | 20.6 | 30.9 | 41.2 | 51.5 | 61.8 | 72.1 | 82.4  | 92.7  | 103 |


### PR DESCRIPTION
Mostly self-explanatory I think. Can be useful reference for determining how long of a passphrase is needed for a given use.