### PR TITLE
Minor updates

### DIFF
--- a/passphraseme/__init__.py
+++ b/passphraseme/__init__.py
@@ -21,19 +21,16 @@ def generate(filename, word_count=7):
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('word_count', metavar='word_count', default=7, type=int, help='Word count')
-    parser.add_argument('-s1', '--short1', action="store_true", help="Use EFF's general short wordlist")
-    parser.add_argument('-s2', '--short2', action="store_true", help="Use EFF's short wordlist with unique prefixes")
-    parser.add_argument('-d', '--dictionary', nargs='?', metavar='dictionary', help='Custom wordlist filename')
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument('-s1', '--short1', action="store_true", help="Use EFF's general short wordlist")
+    group.add_argument('-s2', '--short2', action="store_true", help="Use EFF's short wordlist with unique prefixes")
+    group.add_argument('-d', '--dictionary', nargs='?', metavar='dictionary', help='Custom wordlist filename')
     args = parser.parse_args()
 
     if args.dictionary is not None:
         filename = args.dictionary
     else:
         wordlists_path = os.path.join(os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe()))), 'wordlists')
-
-        if args.short1 and args.short2:
-            print("Select only one wordlist")
-            sys.exit()
 
         if args.short1:
             filename = os.path.join(wordlists_path, 'eff_short_wordlist_1.txt')

--- a/passphraseme/__init__.py
+++ b/passphraseme/__init__.py
@@ -20,7 +20,7 @@ def generate(filename, word_count=7):
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument('word_count', metavar='word_count', default=7, help='Word count')
+    parser.add_argument('word_count', metavar='word_count', default=7, type=int, help='Word count')
     parser.add_argument('-s1', '--short1', action="store_true", help="Use EFF's general short wordlist")
     parser.add_argument('-s2', '--short2', action="store_true", help="Use EFF's short wordlist with unique prefixes")
     parser.add_argument('-d', '--dictionary', nargs='?', metavar='dictionary', help='Custom wordlist filename')
@@ -42,11 +42,7 @@ def main():
         else:
             filename = os.path.join(wordlists_path, 'eff_large_wordlist.txt')
 
-    if not args.word_count.isdigit():
-        print("Please input a valid number.")
-        sys.exit()
-
-    passphrase = generate(filename, int(args.word_count))
+    passphrase = generate(filename, args.word_count)
     print(passphrase)
 
 


### PR DESCRIPTION
* [Using `type=int`](https://docs.python.org/3/library/argparse.html#type) guarantees that only an integer can be entered (allows the `isdigit()` check to be removed)
* [Using a `mutually_exclusive_group`](https://docs.python.org/3/library/argparse.html#argparse.ArgumentParser.add_mutually_exclusive_group) guarantees that only one wordlist argument can be entered (allows the `args.short1 and args.short2` check to be removed)

There was one other option that I didn't add into this PR but I just wanted to mention it. [If you were to use `type=argparse.FileType('r')`](https://docs.python.org/3/library/argparse.html#filetype-objects) for the dictionary argument, the script would automatically throw an error if the filename didn't exist. At first glance, that would seem to be able to get rid of the `try/except FileNotFoundError` in the `generate` function. One problem could be if somehow the EFF wordlists were moved/deleted, trying to open one of those (instead of a custom wordlist) could still raise that error though.
