### PR TITLE
Requires python 3.6+ (for the secrets module), and version bump to 0.1.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,14 +5,14 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="passphraseme",
-    version="0.1.2",
+    version="0.1.3",
     author="Micah Lee",
     author_email="micah@micahflee.com",
     description="A quick and simple cryptographically secure script to generate high entropy passphrases using the Electronic Frontier Foundation's wordlists",
     long_description=long_description,
     long_description_content_type="text/markdown",
     license="GPLv3+",
-    python_requires=">=3.4",
+    python_requires=">=3.6",
     url="https://github.com/micahflee/passphraseme",
     packages=['passphraseme'],
     package_data={'passphraseme': ['wordlists/*.txt']},


### PR DESCRIPTION
Resolves #12.

You can install this test version from the test PyPI server like this:

```sh
pip3 install --upgrade --index-url https://test.pypi.org/simple/ passphraseme
```

Does this fix it?