### PR TITLE
Removes words with non-ASCII characters and f-word from 3 fandom word lists

### DIFF
--- a/passphraseme/wordlists/gameofthrones-2018.txt
+++ b/passphraseme/wordlists/gameofthrones-2018.txt
@@ -837,7 +837,6 @@ darker
 darkness
 dart
 daughter
-daughter-fucking
 daughters
 dawn
 daybreak
@@ -1019,7 +1018,6 @@ done
 donned
 donnel
 dons
-don�t
 door
 doors
 doran
@@ -1425,8 +1423,6 @@ frost-covered
 frostfangs
 frosty
 frozen
-fuck
-�fuck
 fulfil
 fulfill
 fulfilling
@@ -3893,7 +3889,6 @@ well-fed
 went
 wept
 were
-we�re
 west
 western
 westeros

--- a/passphraseme/wordlists/startrek-2018.txt
+++ b/passphraseme/wordlists/startrek-2018.txt
@@ -864,7 +864,6 @@ crush
 cry
 cryptobiosis
 crystal
-c�sar
 cube
 culture
 cumulative
@@ -1404,7 +1403,6 @@ fellow
 felt
 fend
 few
-fianc�e
 field
 fifteen
 fifty
@@ -1508,7 +1506,6 @@ frightened
 from
 front
 frontal
-fucking
 fulfill
 full
 fumes

--- a/passphraseme/wordlists/starwars-2018.txt
+++ b/passphraseme/wordlists/starwars-2018.txt
@@ -1217,7 +1217,6 @@ escort
 escorting
 escorts
 espa
-espa�a
 essentially
 establish
 estimated
@@ -2288,7 +2287,6 @@ mustafar
 musters
 mutilated
 mutiny
-�mwe
 mygeeto
 mynocks
 mysterious
@@ -2462,7 +2460,6 @@ ozzel
 packet
 padawan
 padawans
-padm�
 paige
 pain
 pair
@@ -3791,7 +3788,6 @@ valid
 valuable
 vander
 vandor
-vane�
 vanished
 vanishes
 varactyl
@@ -3838,7 +3834,6 @@ volcanic
 volley
 volunteer
 vos
-vos�
 vows
 vulnerability
 vulnerable


### PR DESCRIPTION
A lighter alternative to the changes proposed in #19 . 

Note that these three lists now have fewer than 4,000 words. Replacement words can be added, or they can be left at their current lengths. If left at the lengths in this PR, table in README will have to be updated. Again, see #19 for a more comprehensive edit to these lists.