### PR TITLE
Allow various wordlists files to be used at once

### DIFF
--- a/passphraseme/__init__.py
+++ b/passphraseme/__init__.py
@@ -10,9 +10,12 @@ except:
     from random import SystemRandom
 
 
-def generate(filename, word_count, sep):
-    with open(filename) as f:
-        words = [line.rstrip("\n") for line in f]
+def generate(filenames, word_count, sep):
+    words = set()
+    for filename in filenames:
+        with open(filename) as f:
+            words = words.union([line.rstrip("\n") for line in f])
+    words = list(words)
 
     try:
         return sep.join(choice(words) for _ in range(word_count))
@@ -40,79 +43,78 @@ def main():
         type=str,
         help="Separator",
     )
-    group = parser.add_mutually_exclusive_group()
-    group.add_argument(
+    parser.add_argument(
         "-l", "--large", action="store_true", help="Use EFF's general large wordlist"
     )
-    group.add_argument(
+    parser.add_argument(
         "-s1", "--short1", action="store_true", help="Use EFF's general short wordlist"
     )
-    group.add_argument(
+    parser.add_argument(
         "-s2",
         "--short2",
         action="store_true",
         help="Use EFF's short wordlist with unique prefixes",
     )
-    group.add_argument(
+    parser.add_argument(
         "-got",
         "--game-of-thrones",
         action="store_true",
         help="Use EFF's Game of Thrones wordlist (Passwords of Westeros)",
     )
-    group.add_argument(
+    parser.add_argument(
         "-hp",
         "--harry-potter",
         action="store_true",
         help="Use EFF's Harry Potter wordlist (Accio Passphrase!)",
     )
-    group.add_argument(
+    parser.add_argument(
         "-st",
         "--star-trek",
         action="store_true",
         help="Use EFF's Star Trek wordlist (Live Long and Passphrase)",
     )
-    group.add_argument(
+    parser.add_argument(
         "-sw",
         "--star-wars",
         action="store_true",
         help="Use EFF's Star Wars wordlist (The Passphrase Is Strong With This One)",
     )
-    group.add_argument(
+    parser.add_argument(
         "-d",
         "--dictionary",
         nargs="?",
         metavar="dictionary",
-        type=argparse.FileType("r"),
-        help="Custom wordlist filename",
+        type=str,
+        help="Path to custom wordlist file",
     )
     args = parser.parse_args()
 
+    wordlists_path = os.path.join(
+        os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe()))),
+        "wordlists",
+    )
+
+    filenames = []
     if args.dictionary is not None:
-        filename = args.dictionary.name
-    else:
-        wordlists_path = os.path.join(
-            os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe()))),
-            "wordlists",
-        )
+        filenames.append(args.dictionary)
+    if args.large:
+        filenames.append(os.path.join(wordlists_path, "eff_large_wordlist.txt"))
+    if args.short1:
+        filenames.append(os.path.join(wordlists_path, "eff_short_wordlist_1.txt"))
+    if args.short2:
+        filenames.append(os.path.join(wordlists_path, "eff_short_wordlist_2_0.txt"))
+    if args.game_of_thrones:
+        filenames.append(os.path.join(wordlists_path, "gameofthrones-2018.txt"))
+    if args.harry_potter:
+        filenames.append(os.path.join(wordlists_path, "harrypotter-2018.txt"))
+    if args.star_trek:
+        filenames.append(os.path.join(wordlists_path, "startrek-2018.txt"))
+    if args.star_wars:
+        filenames.append(os.path.join(wordlists_path, "starwars-2018.txt"))
+    if not filenames:
+        filenames.append(os.path.join(wordlists_path, "eff_short_wordlist_1.txt"))
 
-        if args.large:
-            filename = os.path.join(wordlists_path, "eff_large_wordlist.txt")
-        if args.short1:
-            filename = os.path.join(wordlists_path, "eff_short_wordlist_1.txt")
-        elif args.short2:
-            filename = os.path.join(wordlists_path, "eff_short_wordlist_2_0.txt")
-        elif args.game_of_thrones:
-            filename = os.path.join(wordlists_path, "gameofthrones-2018.txt")
-        elif args.harry_potter:
-            filename = os.path.join(wordlists_path, "harrypotter-2018.txt")
-        elif args.star_trek:
-            filename = os.path.join(wordlists_path, "startrek-2018.txt")
-        elif args.star_wars:
-            filename = os.path.join(wordlists_path, "starwars-2018.txt")
-        else:
-            filename = os.path.join(wordlists_path, "eff_short_wordlist_1.txt")
-
-    passphrase = generate(filename, args.word_count, args.sep)
+    passphrase = generate(filenames, args.word_count, args.sep)
     print(passphrase)
 
 


### PR DESCRIPTION
This change solves #18 by allowing various wordlists (i.e. GOT & Star Trek & Harry Potter) to be used simultaneously. 

It supports using a custom file with words separated by newlines (with the other wordlists or alone). For this to work the `dictionary` argument now is the path to the local file.

PS. Sorry if you dislike anything, this is my first try to solve an issue in a open repo 🫣.